### PR TITLE
publish song analysis

### DIFF
--- a/src/controllers/submission/commit.ts
+++ b/src/controllers/submission/commit.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { type Response } from 'express';
+import type { ParamsDictionary } from 'express-serve-static-core';
+import type { ParsedQs } from 'qs';
+import { z } from 'zod';
+
+import { type CommitSubmissionResult, SUBMISSION_STATUS } from '@overture-stack/lyric';
+
+import { hasUserWriteAccess, shouldBypassAuth } from '@/common/auth.js';
+import logger from '@/common/logger.js';
+import { lyricProvider } from '@/core/provider.js';
+import { type RequestValidation, validateRequest } from '@/middleware/requestValidation.js';
+import { publishMappedSubmissionFiles } from '@/service/fileService.js';
+
+interface CommitPathParams extends ParamsDictionary {
+	submissionId: string;
+	categoryId: string;
+}
+
+export const CommitRequestSchema: RequestValidation<object, ParsedQs, CommitPathParams> = {
+	pathParams: z.object({
+		categoryId: z.string(),
+		submissionId: z.string(),
+	}),
+};
+
+export const commit = validateRequest(CommitRequestSchema, async (req, res: Response<CommitSubmissionResult>, next) => {
+	try {
+		const categoryId = Number(req.params.categoryId);
+		const submissionId = Number(req.params.submissionId);
+		const user = req.user;
+
+		logger.info(`Request Commit Active Submission '${submissionId}' on category '${categoryId}`);
+
+		const submission = await lyricProvider.services.submission.getSubmissionById(submissionId);
+
+		if (!submission) {
+			throw new lyricProvider.utils.errors.BadRequest(`Submission '${submissionId}' not found`);
+		}
+
+		// Authorization check
+		if (!shouldBypassAuth(req.method) && !hasUserWriteAccess(submission.organization, user)) {
+			throw new lyricProvider.utils.errors.Forbidden(
+				`User is not authorized to commit the submission from '${submission.organization}'`,
+			);
+		}
+
+		if (submission.status !== SUBMISSION_STATUS.VALID) {
+			throw new lyricProvider.utils.errors.StatusConflict(
+				`Submission does not have status VALID and cannot be committed`,
+			);
+		}
+
+		const resultPublishSubmissionFiles = await publishMappedSubmissionFiles(submission.organization, submission.id);
+
+		if (!resultPublishSubmissionFiles.success) {
+			throw new lyricProvider.utils.errors.StatusConflict(
+				`Cannot commit submission. Files with analysis IDs ${resultPublishSubmissionFiles.failed} are missing in object storage`,
+			);
+		}
+
+		const username = user?.username || '';
+
+		const commitSubmission = await lyricProvider.services.submission.commitSubmission(
+			categoryId,
+			submissionId,
+			username,
+		);
+
+		return res.status(200).send(commitSubmission);
+	} catch (error) {
+		next(error);
+	}
+});

--- a/src/controllers/submission/getSubmissionById.ts
+++ b/src/controllers/submission/getSubmissionById.ts
@@ -28,7 +28,7 @@ import { shouldBypassAuth } from '@/common/auth.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { type RequestValidation, validateRequest } from '@/middleware/requestValidation.js';
-import { getSubmissionFiles } from '@/service/fileService.js';
+import { buildSubmissionFileMetadata } from '@/service/fileService.js';
 import type { ErrorResponse } from '@/submission/submitRequest.js';
 
 interface GetSubmissionRequestPathParams extends ParamsDictionary {
@@ -77,7 +77,7 @@ export const getSubmissionById = validateRequest(
 				throw new lyricProvider.utils.errors.NotFound(`Submission with id '${submissionId}' not found`);
 			}
 
-			const files = await getSubmissionFiles(submission.organization, submissionId);
+			const files = await buildSubmissionFileMetadata(submission.organization, submissionId);
 
 			const result: GetSubmissionResponse = {
 				...submission,

--- a/src/routers/submission.ts
+++ b/src/routers/submission.ts
@@ -23,6 +23,7 @@ import multer from 'multer';
 import { errorHandler } from '@overture-stack/lyric';
 
 import { env } from '@/common/envConfig.js';
+import { commit } from '@/controllers/submission/commit.js';
 import { editData } from '@/controllers/submission/editData.js';
 import { getSubmissionById } from '@/controllers/submission/getSubmissionById.js';
 import { submit } from '@/controllers/submission/submit.js';
@@ -38,6 +39,7 @@ export const submissionRouter: Router = (() => {
 
 	router.get('/:submissionId', authMiddleware, getSubmissionById);
 	router.post('/category/:categoryId/data', authMiddleware, upload.single('submissionFile'), submit);
+	router.post('/category/:categoryId/commit/:submissionId', authMiddleware, commit);
 	router.put('/category/:categoryId/data', authMiddleware, upload.array('files'), editData);
 
 	router.use('', lyricProvider.routers.submission);


### PR DESCRIPTION
# Description
In the commit submission endpoint, add a check to ensure that all associated files have been published before allowing the submission to be committed.


## Details
- Implement a custom controller to override the default **Lyric Provider** commit controller.
- The custom controller should check whether the Submission includes sequencing files.
- If sequencing files are present, trigger a publish request to **SONG**, which verifies that each file exists in object storage.
- If any file is missing in object storage, the application returns a **409 Conflict** response and prevent the submission from being committed.
- Only proceed with committing the Submission if all associated files have been successfully published in **SONG**.

## Issues related:
- https://github.com/virusseq/roadmap/issues/80