### PR TITLE
Append sequencing files to open submissions

### DIFF
--- a/.dev/docs/index.md
+++ b/.dev/docs/index.md
@@ -1,0 +1,3 @@
+# Internal docs index
+
+- [Sequencing metadata submission](submission/sequencing-metadata-submission.md): design rationale for attaching sequencing files to an already-active Submission without a new submission file

--- a/.dev/docs/submission/sequencing-metadata-submission.md
+++ b/.dev/docs/submission/sequencing-metadata-submission.md
@@ -1,0 +1,22 @@
+# Sequencing metadata submission without a new data file
+
+`POST /submission/category/{categoryId}/data` accepts a request with no `submissionFile`, as long as `sequencingMetadata` is provided and the caller already has an active Submission for that organization. In that case the request attaches the given sequencing files to the existing active Submission instead of creating new clinical data records. See [`docs`](https://github.com/imicroseq/submission-service/blob/main/src/api-docs/submission-api.yml) for the consumer-facing request/response shape.
+
+## Why this exists
+
+Sequencing files often arrive after their clinical data file: an operator submits clinical records first, then sequencing files for those same records once they're available. Before this change, every submission required a file, so attaching sequencing files to an already-submitted set of records meant re-uploading the original clinical data file just to carry sequencing metadata alongside it.
+
+## How it works
+
+1. `src/controllers/submission/submit.ts` looks up the caller's active Submission for the organization via `lyricProvider.services.submission.getActiveSubmissionByOrganization`. This already filters to submissions with an open status (`OPEN`/`VALID`/`INVALID`) and to the requesting user, so no extra active/ownership check is needed.
+2. If there's no active Submission, or no `sequencingMetadata` was provided, the request fails the same way as before: `submissionFile` is required.
+3. Otherwise `src/submission/submissionHandler.ts`'s `handleSequencingMetadataSubmission` fetches the active Submission's already-staged clinical records via `getSubmissionDetailsById` (`INSERTS` only, filtered to the request's `entityName`), matches them against the provided sequencing metadata, and submits the resulting payload(s) to Song.
+4. The response's `submissionManifest` merges the Submission's already-uploaded files (from `buildSubmissionFileMetadata`) with the newly submitted ones, so it reflects the full current state of the Submission's files, not just what this request added.
+
+## Design decisions
+
+**Why `INSERTS` only, not `UPDATES`.** Sequencing files are matched against clinical records by an identifier column (`SEQUENCING_SUBMISSION_FILENAME_IDENTIFIER_COLUMN`) using flat `Record<string, string>` comparisons. That's the same shape the original file-upload path already used for freshly parsed records, all of which are inserts. Restricting to `INSERTS` keeps the matching behavior identical between the two paths rather than introducing a second comparison shape for edited records.
+
+**Why the Song submission call was refactored to take a `batchName` string instead of an `Express.Multer.File`.** The file-less path has no `Express.Multer.File` to pass, and the file object was only ever used for its `.originalname` in error messages. Passing the batch name directly avoids inventing a placeholder file object for a code path that doesn't have one.
+
+**Why the pure matching logic lives in `src/submission/sequencingPayload.ts`, separate from `submissionHandler.ts`.** `submissionHandler.ts` imports `@/core/provider.js` for `lyricProvider`, and that module's `provider()` factory eagerly opens a Postgres connection and spins up a worker pool as a side effect of being imported (not lazily, on first use). That makes `submissionHandler.ts` untestable without a live Postgres instance: importing it for a `node:test` run hangs indefinitely rather than failing fast. `buildSongSubmissionPayload` and `extractInsertRecordValues` are the two genuinely pure pieces of the sequencing-metadata-matching logic (no I/O beyond reading a static JSON template from disk), so they live in a module that doesn't import the provider, and both `submissionHandler.ts` and `src/submission/sequencingPayload.test.ts` import them from there. See `.dev/tech-debt.md` for the broader testing gaps this doesn't resolve (the orchestration layer and controllers still need either a real test environment or a mocking layer).

--- a/.dev/docs/submission/sequencing-metadata-submission.md
+++ b/.dev/docs/submission/sequencing-metadata-submission.md
@@ -4,7 +4,7 @@
 
 ## Why this exists
 
-Sequencing files often arrive after their clinical data file: an operator submits clinical records first, then sequencing files for those same records once they're available. Before this change, every submission required a file, so attaching sequencing files to an already-submitted set of records meant re-uploading the original clinical data file just to carry sequencing metadata alongside it.
+Sequencing files often arrive after their clinical data file: an operator may submit clinical records together with some of the sequencing files for those same records. Before this change, every submission required a .csv file along with its sequencing files, and it was not possible to append sequencing files to records that had already been submitted.
 
 ## How it works
 

--- a/.dev/sessions/2026-07-24T120325.md
+++ b/.dev/sessions/2026-07-24T120325.md
@@ -7,7 +7,15 @@ Adopted the agentics devctx collaboration template so future sessions have worki
 - `.dev/sessions/`: created this file
 - Project memory: recorded Overture-project status and the initialization answers so they aren't re-asked
 
-Implemented the file-less submission path: submitting sequencing metadata alone now updates an already-active submission's Song files instead of requiring a fresh submission file every time.
+Implemented the file-less submission path: submitting sequencing metadata alone now updates an already-active submission's Song files instead of requiring a fresh submission file every time. Added test and documentation coverage for it, and introduced the repository's first test tooling in the process.
 
 - `src/controllers/submission/submit.ts`: when no file is uploaded, looks up the caller's active submission for the organization and, if one exists with sequencing metadata provided, hands off to the new handler; otherwise still errors that a submission file is required
 - `src/submission/submissionHandler.ts`: added `handleSequencingMetadataSubmission`, matching supplied sequencing metadata against the active submission's already-staged clinical records, submitting to Song, and returning a manifest merging existing and newly submitted files; `submitSongPayload` now takes a `batchName` string instead of a full `Express.Multer.File`, since only the filename was ever used from it
+- `src/submission/sequencingPayload.ts`: extracted `buildSongSubmissionPayload` and the new `extractInsertRecordValues` out of `submissionHandler.ts` into their own module, since `submissionHandler.ts` imports `@/core/provider.js`, whose `provider()` factory eagerly opens a Postgres connection and worker pool as an import-time side effect and hangs any test that imports it without a live database; this pure module has no such dependency
+- `src/submission/sequencingPayload.test.ts`: first test file in the repository; BDD coverage for the two functions above via `node:test`
+- `package.json`, `tsconfig.json`: added a `test` script (`node --env-file=.env.test --import tsx --test`) and excluded `*.test.ts` from the compiled build output, mirroring the existing `*.spec.ts` exclusion
+- `.env.test`: committed, non-secret placeholder environment values (all optional services disabled) so `pnpm test` parses `envConfig.ts` without a developer's real `.env`; verified by running the suite with `.env` temporarily removed
+- `.dev/tech-debt.md`: narrowed the "no test suite" entry to reflect the coverage that now exists; added entries for the `core/provider.js` import-time hang, the still-missing CI workflow to actually run `pnpm test`/`pnpm lint`/`tsc --noEmit`, and `buildSequencingFilesMetadata` reading `env` directly instead of taking it as a parameter
+- `src/api-docs/submission-api.yml`: documented that `submissionFile` is optional when an Active Submission already exists and `sequencingMetadata` is provided
+- `.dev/docs/submission/sequencing-metadata-submission.md`: new internal design note explaining why the feature exists and the testability-driven module split; `.dev/docs/index.md` created to index it
+- `DEVELOPMENT.md`: "Running tests" section now reflects the working `pnpm test` command and its constraints; broadened the `.dev/docs` description to cover design-rationale docs, not just service deployment guides

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -19,3 +19,7 @@ standalone: yes
 `buildSequencingFilesMetadata` (`src/submission/fileValidation.ts`) reads `env.SEQUENCING_SUBMISSION_FILENAME_IDENTIFIER_COLUMN` directly instead of receiving it as a parameter, violating this project's own "library code must not read from the environment" constraint and blocking a clean, deterministic unit test of its env-dependent branches
 fix: thread the identifier column through as a function parameter (the caller already reads it from `env` once), the same way `fileNameIdentifier` is already passed into `buildSongSubmissionPayload`
 standalone: yes
+
+`handleSequencingMetadataSubmission` (`src/submission/submissionHandler.ts`) fetches a Submission's clinical records via `getSubmissionDetailsById` with `pageSize` set to the full record count, i.e. one unbounded query per append call. Raised during review of the sequencing-metadata-append feature since it's the same class of problem ("large submission") that motivates this feature in the first place. Per Lyric's current storage model, this isn't actually fixable here: Lyric stores a Submission's data as a single JSONB column, so there's no partial-fetch to page or stream against
+fix: revisit once the Lyric dependency ships the version that gives more granular control over Submission data storage; until then there's no code change to make on this side
+standalone: yes

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -4,6 +4,18 @@ Known issues, scope-adjacent problems, and deferred work. See `CLAUDE.md`/`AGENT
 
 ---
 
-No automated test suite exists in this repository
-fix: introduce `node:test`-based BDD tests co-located with source files (see `CLAUDE.md`/`AGENTS.md` § Testing) starting with the next feature or bug fix touched, rather than a single big backfill effort; add a `test` script to `package.json` once the first test file exists
+Only pure-logic functions have test coverage; the DB/Song-facing submission orchestration and Express controllers remain untested
+fix: `pnpm test` now runs co-located `node:test` BDD tests (`src/submission/sequencingPayload.test.ts`), started with the sequencing-metadata-submission feature per `CLAUDE.md`/`AGENTS.md` § Testing. Extend the same way for each new feature or bug fix touched, rather than a single big backfill effort. Testing the orchestration layer (`submissionHandler.ts`'s `handleSubmission`/`handleSequencingMetadataSubmission`, the `submit`/`getSubmissionById` controllers) needs either a real Postgres+Lectern+Song test environment or a mocking layer for `lyricProvider`/`song.ts`/`fileRepository`, neither of which exists yet
+standalone: yes
+
+Importing `@/core/provider.js` (directly, or transitively through any module that imports it, e.g. `submissionHandler.ts`) hangs a `node:test` run indefinitely without a live Postgres connection: the lyric `provider()` factory eagerly connects and spins up a worker pool as a module-level side effect, it isn't lazy or deferred to first use
+fix: keep pure business logic (no DB/HTTP orchestration) in modules that don't import `@/core/provider.js`, following the split already made between `sequencingPayload.ts` (pure, tested) and `submissionHandler.ts` (orchestration, imports the provider). Don't add tests that import `submissionHandler.ts` or `core/provider.ts` directly without a real Postgres instance running
+standalone: yes
+
+No CI workflow runs `pnpm test` (or `pnpm lint`/`tsc --noEmit`) on pushes or PRs
+fix: add a GitHub Actions workflow that runs them. `pnpm test` itself no longer needs a real `.env`: `.env.test` (committed, non-secret placeholder values) is loaded via `--env-file=.env.test` in the `test` script, so `envConfig.ts`'s required vars (`DB_HOST`, `DB_NAME`, `DB_PASSWORD`, `DB_PORT`, `DB_USER`, `LECTERN_URL`) resolve without a developer's local `.env` present
+standalone: yes
+
+`buildSequencingFilesMetadata` (`src/submission/fileValidation.ts`) reads `env.SEQUENCING_SUBMISSION_FILENAME_IDENTIFIER_COLUMN` directly instead of receiving it as a parameter, violating this project's own "library code must not read from the environment" constraint and blocking a clean, deterministic unit test of its env-dependent branches
+fix: thread the identifier column through as a function parameter (the caller already reads it from `env` once), the same way `fileNameIdentifier` is already passed into `buildSongSubmissionPayload`
 standalone: yes

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,22 @@
+# Non-secret environment values for `pnpm test` (see DEVELOPMENT.md § Running tests).
+# Committed on purpose: no real credentials, no reachable services required. Only lets
+# `src/common/envConfig.ts` parse successfully so modules that import it can be loaded
+# by tests that don't touch a real Postgres/Lectern/Song instance.
+# See .dev/tech-debt.md for the tests this does not unblock (anything importing
+# @/core/provider.js still needs a live Postgres connection).
+
+AUDIT_ENABLED=false
+AUTH_ENABLED=false
+INDEXER_ENABLED=false
+SEQUENCING_SUBMISSION_ENABLED=false
+
+DB_HOST=localhost
+DB_NAME=test
+DB_PASSWORD=test
+DB_PORT=5432
+DB_USER=test
+
+LECTERN_URL=http://localhost:3000
+
+LOG_LEVEL=error
+# NODE_ENV is left unset (defaults to "development"): the schema only allows development/production, no "test" option

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,10 @@
 
 ## Running tests
 
-No automated test suite exists in this repository yet (no `*.test.ts`/`*.spec.ts` files, no test script in `package.json`). New and changed code should follow the co-located, BDD-style `node:test` convention described in `CLAUDE.md`/`AGENTS.md` § Testing; see `.dev/tech-debt.md` for the standing gap.
+- `pnpm test` runs co-located `*.test.ts` files with Node's built-in test runner (`node:test`), transpiled on the fly via `tsx`
+- New and changed code follows the co-located, BDD-style `node:test` convention described in `CLAUDE.md`/`AGENTS.md` § Testing
+- Uses `.env.test` (committed, non-secret placeholder values, loaded via `--env-file`), not your local `.env`: most modules parse environment configuration at import time, so importing them at all fails without some valid values present, real or not. Keep pure business logic in modules that don't import `@/core/provider.js` (see `.dev/tech-debt.md`): importing it, directly or transitively, hangs a test run indefinitely without a live Postgres connection
+- The DB/Song-facing submission orchestration and Express controllers aren't covered yet; see `.dev/tech-debt.md` for what that would take
 
 ## Working documents
 
@@ -53,6 +56,6 @@ The `.dev/` directory contains living documents maintained alongside the codebas
 - `.dev/roadmap.md`: planned features and architectural direction; read at session start
 - `.dev/tech-debt.md`: known issues, scope-adjacent problems, and deferred work
 - `.dev/sessions/`: one file per contributor per day (`YYYY-MM-DDTHHMMSS.md`), brief log of what changed and why
-- `.dev/docs/`: service-specific deployment notes and operational guides; indexed at `.dev/docs/index.md`; one subdirectory per service (e.g. `.dev/docs/postgres/`, `.dev/docs/lectern/`)
+- `.dev/docs/`: internal design rationale and implementation guides (e.g. `.dev/docs/submission/`), plus service-specific deployment notes and operational guides (e.g. `.dev/docs/postgres/`, `.dev/docs/lectern/`); indexed at `.dev/docs/index.md`
 
 Read the `.dev/` files at the start of each session before beginning work. Read the relevant `.dev/docs/<service>/` guide before deploying or debugging a specific service. Update these at the end of any session that produces meaningful output.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG WORKDIR=/usr/src/app
 ######################
 # Configure base image
 ######################
-FROM node:20.12.2-alpine AS base
+FROM node:22-alpine AS base
 
 ARG APP_USER
 ARG WORKDIR
@@ -14,15 +14,16 @@ ARG WORKDIR
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 
-# install pnpm as root user, before updating node ownership
-RUN npm i -g pnpm
-
 # create our own user to run node, don't run node in production as root
 ENV APP_UID=9999
 ENV APP_GID=9999
 RUN addgroup -S -g $APP_GID $APP_USER \
 	&& adduser -S -u $APP_UID -g $APP_GID $APP_USER \
 	&& mkdir -p ${WORKDIR}
+
+ENV COREPACK_HOME=/usr/local/share/corepack
+RUN corepack enable
+RUN corepack prepare pnpm@11.1.1 --activate
 
 WORKDIR ${WORKDIR}
 
@@ -34,14 +35,15 @@ USER ${APP_USER}:${APP_USER}
 # Configure build image
 ######################
 
-FROM base as build
+FROM base AS build
 
 ARG APP_USER
 ARG WORKDIR
 
-COPY --chown=clinical:clinical . ./
+COPY --chown=${APP_USER}:${APP_USER} . ./
+USER ${APP_USER}:${APP_USER}
 
-RUN pnpm install --ignore-scripts
+RUN pnpm install --ignore-scripts --frozen-lockfile
 
 RUN pnpm build:all
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "\n=============  Dev environment  =============": "",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "test": "node --import tsx --test 'src/**/*.test.ts'",
     "db:studio": "NODE_OPTIONS='--import tsx' drizzle-kit studio --config=drizzle.config.ts",
     "db:generate": "NODE_OPTIONS='--import tsx' drizzle-kit generate --config=drizzle.config.ts",
     "migrate:db:dev": "tsx src/scripts/provider-migration.ts && tsx src/scripts/custom-migration.ts",

--- a/src/api-docs/submission-api.yml
+++ b/src/api-docs/submission-api.yml
@@ -231,6 +231,11 @@
 /submission/category/{categoryId}/data:
   post:
     summary: Add new data to a submission for the specified category. Returns an Active Submission containing the newly created records
+    description: >
+      `submissionFile` may be omitted if the caller already has an Active Submission for `organization`
+      and `sequencingMetadata` is provided: the given sequencing files are attached to that existing
+      Active Submission instead of creating a new Submission. Returns `400` if `submissionFile` is omitted and there is no Active Submission, or no
+      `sequencingMetadata` is provided.
     tags:
       - Submission
     consumes:
@@ -246,7 +251,10 @@
               submissionFile:
                 type: string
                 format: binary
-                description: 'The main file containing data records for submission (supported formats: CSV, TSV)'
+                description: >
+                  The main file containing data records for submission (supported formats: CSV, TSV).
+                  Optional when the caller already has an Active Submission for the organization and
+                  `sequencingMetadata` is provided; see the endpoint description.
               entityName:
                 type: string
                 default: ''
@@ -260,7 +268,6 @@
                 description: JSON string representing an array of Metadata for sequencing files. <br />(e.g. '[{"fileName":"SRS00001-ABC123.tar.xz","fileSize":"100", "fileMd5sum":"ABC123", "fileAccess":"open", "fileType":"FASTAQ"}]')
                 default: ''
             required:
-              - submissionFile
               - entityName
               - organization
     responses:

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -26,7 +26,7 @@ import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 import { prevalidateNewDataFile } from '@/submission/fileValidation.js';
-import { handleSubmission } from '@/submission/submissionHandler.js';
+import { handleSequencingMetadataSubmission, handleSubmission } from '@/submission/submissionHandler.js';
 import {
 	type ErrorResponse,
 	type SubmissionManifest,
@@ -61,9 +61,37 @@ export const submit = validateRequest(
 			}
 
 			if (!submissionFile) {
-				throw new lyricProvider.utils.errors.BadRequest(
-					'The "submissionFile" parameter is missing or empty. Please include a file in the request for processing.',
-				);
+				if (!sequencingMetadataValues || sequencingMetadataValues.length === 0) {
+					throw new lyricProvider.utils.errors.BadRequest(
+						'The "submissionFile" parameter is missing or empty. Please include a file in the request for processing.',
+					);
+				}
+				const activeSubmission = sequencingMetadataValues
+					? await lyricProvider.services.submission.getActiveSubmissionByOrganization({
+							categoryId,
+							username: user?.username || '',
+							organization,
+						})
+					: undefined;
+
+				if (!activeSubmission) {
+					throw new lyricProvider.utils.errors.BadRequest(
+						'No active submission found for the provided organization and category. Please ensure that you have an active submission before submitting sequencing metadata.',
+					);
+				}
+
+				const result = await handleSequencingMetadataSubmission({
+					activeSubmission,
+					sequencingMetadataValues,
+					organization,
+					entityName,
+				});
+
+				if (!result.success) {
+					return respondWithInvalidSubmission(res, result.submissionId, result.errors || []);
+				}
+
+				return responseWithProcessingStatus(res, result.submissionId, result.submissionManifest);
 			}
 
 			// Get the current dictionary and validate entity name

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -66,13 +66,11 @@ export const submit = validateRequest(
 						'The "submissionFile" parameter is missing or empty. Please include a file in the request for processing.',
 					);
 				}
-				const activeSubmission = sequencingMetadataValues
-					? await lyricProvider.services.submission.getActiveSubmissionByOrganization({
-							categoryId,
-							username: user?.username || '',
-							organization,
-						})
-					: undefined;
+				const activeSubmission = await lyricProvider.services.submission.getActiveSubmissionByOrganization({
+					categoryId,
+					username: user?.username || '',
+					organization,
+				});
 
 				if (!activeSubmission) {
 					throw new lyricProvider.utils.errors.BadRequest(

--- a/src/submission/sequencingPayload.test.ts
+++ b/src/submission/sequencingPayload.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import assert from 'node:assert/strict';
+import { suite, test } from 'node:test';
+
+import { buildSongSubmissionPayload, extractInsertRecordValues } from './sequencingPayload.js';
+
+suite('extractInsertRecordValues', () => {
+	test('returns an empty array when given no records', () => {
+		const result = extractInsertRecordValues([]);
+		assert.deepEqual(result, []);
+	});
+
+	test('keeps only INSERTS records, filtering out UPDATES and DELETES', () => {
+		const result = extractInsertRecordValues([
+			{ type: 'INSERTS', value: { specimen_collector_sample_id: 'SAMPLE001' } },
+			{ type: 'UPDATES', value: { specimen_collector_sample_id: 'SAMPLE002' } },
+			{ type: 'DELETES', value: { specimen_collector_sample_id: 'SAMPLE003' } },
+		]);
+		assert.deepEqual(result, [{ specimen_collector_sample_id: 'SAMPLE001' }]);
+	});
+
+	test('stringifies non-string field values, defaulting null and undefined to an empty string', () => {
+		const result = extractInsertRecordValues([
+			{ type: 'INSERTS', value: { count: 3, active: true, missing: null, unset: undefined } },
+		]);
+		assert.deepEqual(result, [{ count: '3', active: 'true', missing: '', unset: '' }]);
+	});
+});
+
+suite('buildSongSubmissionPayload', () => {
+	const fileNameIdentifier = 'specimen_collector_sample_id';
+	const organization = 'test-org';
+
+	test('returns an empty array when no sequencing file matches a clinical record', () => {
+		const result = buildSongSubmissionPayload({
+			sequencingFilesMetadata: [
+				{
+					fileName: 'SAMPLE001.fastq.gz',
+					fileSize: 100,
+					fileMd5sum: 'abc123',
+					fileAccess: 'open',
+					fileType: 'FASTQ',
+					identifier: 'SAMPLE001',
+				},
+			],
+			extractedData: [{ specimen_collector_sample_id: 'SAMPLE999' }],
+			organization,
+			fileNameIdentifier,
+		});
+
+		assert.deepEqual(result, []);
+	});
+
+	test('builds a Song payload for each sequencing file matched by the identifier column', () => {
+		const result = buildSongSubmissionPayload({
+			sequencingFilesMetadata: [
+				{
+					fileName: 'SAMPLE001.fastq.gz',
+					fileSize: 100,
+					fileMd5sum: 'abc123',
+					fileAccess: 'open',
+					fileType: 'FASTQ',
+					identifier: 'SAMPLE001',
+				},
+			],
+			extractedData: [
+				{
+					specimen_collector_sample_id: 'SAMPLE001',
+					insdc_project_accession: 'PRJ1',
+					insdc_sample_accession: 'SAM1',
+				},
+				{ specimen_collector_sample_id: 'SAMPLE999' },
+			],
+			organization,
+			fileNameIdentifier,
+		});
+
+		assert.deepEqual(result, [
+			{
+				studyId: 'test-org',
+				analysisType: { name: 'imicroseq_wastewater' },
+				specimen_collector_sample_id: 'SAMPLE001',
+				insdc_project_accession: 'PRJ1',
+				insdc_sample_accession: 'SAM1',
+				files: [
+					{
+						fileName: 'SAMPLE001.fastq.gz',
+						fileSize: 100,
+						fileMd5sum: 'abc123',
+						fileAccess: 'open',
+						fileType: 'FASTQ',
+					},
+				],
+			},
+		]);
+	});
+});

--- a/src/submission/sequencingPayload.ts
+++ b/src/submission/sequencingPayload.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import type { SequencingMetadataType } from '@/submission/submitRequest.js';
+
+import { buildFileMetadata } from './fileValidation.js';
+import { convertRecordToPayload, prefixKeys } from './populateTemplate.js';
+
+// This template is used to convert the sequencing metadata into a payload to Song
+const SEQUENCING_TEMPLATE = 'sequencing_payload.json' as const;
+const DATA_PREFIX = 'data.' as const;
+
+/**
+ * Builds the Song payload based on the Sequencing files Metadata
+ * @param param0
+ * @returns
+ */
+export const buildSongSubmissionPayload = ({
+	sequencingFilesMetadata,
+	extractedData,
+	organization,
+	fileNameIdentifier,
+}: {
+	sequencingFilesMetadata: (SequencingMetadataType & { identifier: string })[];
+	extractedData: Record<string, string>[];
+	organization: string;
+	fileNameIdentifier: string;
+}): Record<string, any>[] => {
+	const songSubmissionData: Record<string, any>[] = [];
+	// Convert Sequencing metadata to payload
+	for (const filesMetadata of sequencingFilesMetadata) {
+		const matchedRecord = extractedData.find((record) => record[fileNameIdentifier] === filesMetadata.identifier);
+
+		if (!matchedRecord) {
+			continue;
+		}
+
+		const prefixedRecord = prefixKeys(matchedRecord, DATA_PREFIX);
+		const songPayload = convertRecordToPayload({ organization, ...prefixedRecord }, SEQUENCING_TEMPLATE);
+		// TODO: Handle multiple files by same identifier
+		songPayload.files = [buildFileMetadata(filesMetadata)];
+
+		songSubmissionData.push(songPayload);
+	}
+	return songSubmissionData;
+};
+
+/**
+ * Flattens Submission Data records down to their INSERTS, converting field values to strings so
+ * they can be matched against sequencing file metadata by `buildSequencingFilesMetadata`.
+ * @param submissionRecords
+ * @returns
+ */
+export const extractInsertRecordValues = (
+	submissionRecords: { type: string; value: Record<string, unknown> }[],
+): Record<string, string>[] =>
+	submissionRecords
+		.filter((record) => record.type === 'INSERTS')
+		.map((record) =>
+			Object.fromEntries(Object.entries(record.value).map(([key, value]) => [key, String(value ?? '')])),
+		);

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -17,20 +17,27 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { ACTIVE_SUBMISSION_STATUS, BATCH_ERROR_TYPE, type BatchError, type Schema } from '@overture-stack/lyric';
+import {
+	ACTIVE_SUBMISSION_STATUS,
+	BATCH_ERROR_TYPE,
+	type BatchError,
+	type Schema,
+	type SubmissionSummary,
+} from '@overture-stack/lyric';
 
 import { env } from '@/common/envConfig.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { type InsertSubmissionFile } from '@/db/schemas/index.js';
+import { buildSubmissionFileMetadata } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
 import { getDbInstance } from '../db/index.js';
 import { fileRepository } from '../repository/fileRepository.js';
-import { buildFileMetadata, buildSequencingFilesMetadata } from './fileValidation.js';
-import { convertRecordToPayload, prefixKeys } from './populateTemplate.js';
+import { buildSequencingFilesMetadata } from './fileValidation.js';
 import { parseFileToRecords } from './readFile.js';
+import { buildSongSubmissionPayload, extractInsertRecordValues } from './sequencingPayload.js';
 
 interface SuccessSubmissionResult {
 	success: true;
@@ -43,45 +50,6 @@ interface ErrorSubmissionResult {
 	submissionId?: number;
 	errors: BatchError[];
 }
-
-// This template is used to convert the sequencing metadata into a payload to Song
-const SEQUENCING_TEMPLATE = 'sequencing_payload.json' as const;
-const DATA_PREFIX = 'data.' as const;
-
-/**
- * Builds the Song payload based on the Sequencing files Metadata
- * @param param0
- * @returns
- */
-const buildSongSubmissionPayload = ({
-	sequencingFilesMetadata,
-	extractedData,
-	organization,
-	fileNameIdentifier,
-}: {
-	sequencingFilesMetadata: (SequencingMetadataType & { identifier: string })[];
-	extractedData: Record<string, string>[];
-	organization: string;
-	fileNameIdentifier: string;
-}): Record<string, any>[] => {
-	const songSubmissionData: Record<string, any>[] = [];
-	// Convert Sequencing metadata to payload
-	for (const filesMetadata of sequencingFilesMetadata) {
-		const matchedRecord = extractedData.find((record) => record[fileNameIdentifier] === filesMetadata.identifier);
-
-		if (!matchedRecord) {
-			continue;
-		}
-
-		const prefixedRecord = prefixKeys(matchedRecord, DATA_PREFIX);
-		const songPayload = convertRecordToPayload({ organization, ...prefixedRecord }, SEQUENCING_TEMPLATE);
-		// TODO: Handle multiple files by same identifier
-		songPayload.files = [buildFileMetadata(filesMetadata)];
-
-		songSubmissionData.push(songPayload);
-	}
-	return songSubmissionData;
-};
 
 /**
  * Constructs an array of data to be used for the file Manifest
@@ -110,7 +78,7 @@ const buildSubmissionManifest = async (analysisIds: string[], organization: stri
  * @param organization
  * @param submissionId
  * @param fileNameIdentifier
- * @param submissionFile
+ * @param batchName Name used to identify the batch in error reporting
  * @returns
  */
 const submitSongPayload = async (
@@ -118,7 +86,7 @@ const submitSongPayload = async (
 	organization: string,
 	submissionId: number,
 	fileNameIdentifier: string,
-	submissionFile: Express.Multer.File,
+	batchName: string,
 ): Promise<{ success: true; analysisIds: string[] } | ErrorSubmissionResult> => {
 	const db = getDbInstance();
 	const fileRepo = fileRepository(db);
@@ -141,7 +109,7 @@ const submitSongPayload = async (
 			songErrors.push({
 				message: error?.toString() || 'Unknown error',
 				type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-				batchName: submissionFile.originalname,
+				batchName,
 			});
 		}
 	}
@@ -172,7 +140,7 @@ const submitSongPayload = async (
 				{
 					message: error?.toString() || 'Unknown error',
 					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-					batchName: submissionFile.originalname,
+					batchName,
 				},
 			],
 		};
@@ -269,7 +237,7 @@ export async function handleSubmission({
 		organization,
 		lyricSubmitResult.submissionId,
 		fileNameIdentifier,
-		submissionFile,
+		submissionFile.originalname,
 	);
 
 	if (!songSubmissionResult.success) {
@@ -291,5 +259,112 @@ export async function handleSubmission({
 		success: true,
 		submissionId: lyricSubmitResult.submissionId,
 		submissionManifest: manifest,
+	};
+}
+
+/**
+ * Handles submission of sequencing metadata against an already active Submission,
+ * with no new submission file. Matches the provided sequencing metadata against the
+ * clinical records already staged on the active Submission and submits the resulting
+ * payload(s) to Song.
+ * @param param0
+ * @returns
+ */
+export async function handleSequencingMetadataSubmission({
+	activeSubmission,
+	sequencingMetadataValues,
+	organization,
+	entityName,
+}: {
+	activeSubmission: SubmissionSummary;
+	sequencingMetadataValues: SequencingMetadataType[];
+	organization: string;
+	entityName: string;
+}): Promise<SuccessSubmissionResult | ErrorSubmissionResult> {
+	const fileNameIdentifier = env.SEQUENCING_SUBMISSION_FILENAME_IDENTIFIER_COLUMN || '';
+	const sequencingEnabled = env.SEQUENCING_SUBMISSION_ENABLED;
+	const submissionId = activeSubmission.id;
+	const batchName = `Submission ${submissionId}`;
+
+	if (!fileNameIdentifier || !sequencingEnabled) {
+		return {
+			success: false,
+			submissionId,
+			errors: [
+				{
+					message: 'Sequencing file submission is not enabled for this category.',
+					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+					batchName,
+				},
+			],
+		};
+	}
+
+	// Grab the clinical records already staged on the active Submission to match against the sequencing metadata
+	const { data: submissionRecords } = await lyricProvider.services.submission.getSubmissionDetailsById({
+		submissionId,
+		paginationOptions: { page: 1, pageSize: Math.max(activeSubmission.data.total, 1) },
+		filterOptions: { entityNames: [entityName], actionTypes: ['INSERTS'] },
+	});
+
+	const extractedData = extractInsertRecordValues(submissionRecords);
+
+	const { errors, validFiles: sequencingFilesMetadata } = buildSequencingFilesMetadata(
+		sequencingMetadataValues,
+		extractedData,
+		batchName,
+	);
+
+	if (errors.length > 0) {
+		logger.info(`Error validation sequencing file metadata: ${JSON.stringify(errors)}`);
+		return { success: false, submissionId, errors };
+	}
+
+	const songSubmissionData = buildSongSubmissionPayload({
+		sequencingFilesMetadata,
+		extractedData,
+		organization,
+		fileNameIdentifier,
+	});
+
+	if (!songSubmissionData.length) {
+		return {
+			success: false,
+			submissionId,
+			errors: [
+				{
+					message: 'No sequencing files matched the records of the current active Submission.',
+					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+					batchName,
+				},
+			],
+		};
+	}
+
+	const songSubmissionResult = await submitSongPayload(
+		songSubmissionData,
+		organization,
+		submissionId,
+		fileNameIdentifier,
+		batchName,
+	);
+
+	if (!songSubmissionResult.success) {
+		return songSubmissionResult;
+	}
+
+	// Combine the Submission's existing files with the newly submitted sequencing files
+	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
+	const newFiles = await buildSubmissionManifest(songSubmissionResult.analysisIds, organization);
+
+	const submissionManifest: SubmissionManifest[] = [
+		...existingFiles.map(({ objectId, fileName, md5Sum }) => ({ objectId, fileName, md5Sum })),
+		...newFiles,
+	];
+
+	return {
+		success: true,
+		submissionId,
+		submissionManifest,
 	};
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
 	},
 	"include": ["./src/**/*.ts", "register.ts", "./src/templates/*.json"],
-	"exclude": ["dist", "node_modules", "**/*.spec.ts", "*.config.js"]
+	"exclude": ["dist", "node_modules", "**/*.spec.ts", "**/*.test.ts", "*.config.js"]
 }


### PR DESCRIPTION
# Summary
Append Sequencing files metadata to an existing open and valid Submission. 

## Details
- `POST /submission/category/{categoryId}/data` endpoint updated to remove requirement of field `submissionFile ` (.csv) file, making it optional.
- Updated Open api docs
- Updated docs (`sequencing-metadata-submission.md` )

>Note: This PR is required by Portal UI [PR](https://github.com/imicroseq/portal-ui/pull/522)
