### PR TITLE
Fix: Submit duplicate sequencing files

### DIFF
--- a/migrations/0003_add_md5_sum_column_map_table.sql
+++ b/migrations/0003_add_md5_sum_column_map_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "submission"."record_analysis_map" ADD COLUMN "md5_sum" varchar(255);

--- a/migrations/meta/0003_snapshot.json
+++ b/migrations/meta/0003_snapshot.json
@@ -1,0 +1,108 @@
+{
+  "id": "63b307b1-1d0e-413e-acac-d3574dde2028",
+  "prevId": "2e627443-e322-4ddf-9471-40c9c27fcdfe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "submission.record_analysis_map": {
+      "name": "record_analysis_map",
+      "schema": "submission",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_identifier": {
+          "name": "record_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_id": {
+          "name": "analysis_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "md5_sum": {
+          "name": "md5_sum",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submission_id_idx": {
+          "name": "submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "system_id_idx": {
+          "name": "system_id_idx",
+          "columns": [
+            {
+              "expression": "system_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "submission": "submission"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1752690000762,
       "tag": "0002_add_system_id_colum_map_table",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1787078241227,
+      "tag": "0003_add_md5_sum_column_map_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -19,14 +19,18 @@
 
 import { type Response } from 'express';
 
-import { ACTIVE_SUBMISSION_STATUS, type BatchError } from '@overture-stack/lyric';
+import { ACTIVE_SUBMISSION_STATUS, BATCH_ERROR_TYPE, type BatchError } from '@overture-stack/lyric';
 
 import { hasUserWriteAccess, shouldBypassAuth } from '@/common/auth.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 import { prevalidateNewDataFile } from '@/submission/fileValidation.js';
-import { handleSequencingMetadataSubmission, handleSubmission } from '@/submission/submissionHandler.js';
+import {
+	findDuplicateSequencingMetadata,
+	handleSequencingMetadataSubmission,
+	handleSubmission,
+} from '@/submission/submissionHandler.js';
 import {
 	type ErrorResponse,
 	type SubmissionManifest,
@@ -58,6 +62,21 @@ export const submit = validateRequest(
 					error: 'Forbidden',
 					message: `User is not authorized to submit data to '${organization}'`,
 				});
+			}
+
+			// Input validation - Find duplicate md5sums in sequencing metadata input
+			if (sequencingMetadataValues && sequencingMetadataValues.length > 0) {
+				const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
+
+				if (duplicateMetadataFiles.length) {
+					return respondWithInvalidSubmission(res, undefined, [
+						{
+							message: `The following files have duplicate md5sum values: ${duplicateMetadataFiles.map((metadata) => metadata.fileName).join(', ')}`,
+							type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+							batchName: submissionFile?.originalname || '',
+						},
+					]);
+				}
 			}
 
 			if (!submissionFile) {

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -19,14 +19,15 @@
 
 import { type Response } from 'express';
 
-import { ACTIVE_SUBMISSION_STATUS, BATCH_ERROR_TYPE, type BatchError } from '@overture-stack/lyric';
+import { ACTIVE_SUBMISSION_STATUS, type BatchError, type SubmissionSummary } from '@overture-stack/lyric';
 
 import { hasUserWriteAccess, shouldBypassAuth } from '@/common/auth.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
+import { fetchSubmissionFilesBySubmissionId } from '@/service/fileService.js';
 import { prevalidateNewDataFile } from '@/submission/fileValidation.js';
-import { findDuplicateSequencingMetadata } from '@/submission/sequencingPayload.js';
+import { getAlreadySubmittedFilesError, getDuplicateSequencingMetadataError } from '@/submission/sequencingPayload.js';
 import { handleSequencingMetadataSubmission, handleSubmission } from '@/submission/submissionHandler.js';
 import {
 	type ErrorResponse,
@@ -61,18 +62,40 @@ export const submit = validateRequest(
 				});
 			}
 
-			// Input validation - Find duplicate md5sums in sequencing metadata input
-			if (sequencingMetadataValues && sequencingMetadataValues.length > 0) {
-				const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
+			if (!submissionFile && (!sequencingMetadataValues || sequencingMetadataValues.length === 0)) {
+				throw new lyricProvider.utils.errors.BadRequest(
+					'Missing submission file and sequencing metadata. Please provide at least one of these for processing.',
+				);
+			}
 
-				if (duplicateMetadataFiles.length) {
-					return respondWithInvalidSubmission(res, undefined, [
-						{
-							message: `The following files have duplicate md5sum values: ${duplicateMetadataFiles.map((metadata) => metadata.fileName).join(', ')}`,
-							type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-							batchName: submissionFile?.originalname || '',
-						},
-					]);
+			let activeSubmission: SubmissionSummary | undefined;
+
+			if (sequencingMetadataValues?.length) {
+				const duplicateMetadataError = getDuplicateSequencingMetadataError(
+					sequencingMetadataValues,
+					submissionFile?.originalname,
+				);
+				if (duplicateMetadataError) {
+					return respondWithInvalidSubmission(res, undefined, [duplicateMetadataError]);
+				}
+
+				activeSubmission = await lyricProvider.services.submission.getActiveSubmissionByOrganization({
+					categoryId,
+					username: user?.username || '',
+					organization,
+				});
+
+				if (activeSubmission) {
+					const existingSubmissionFiles = await fetchSubmissionFilesBySubmissionId(activeSubmission.id);
+					const alreadySubmittedError = getAlreadySubmittedFilesError(
+						existingSubmissionFiles,
+						sequencingMetadataValues,
+						submissionFile?.originalname,
+					);
+
+					if (alreadySubmittedError) {
+						return respondWithInvalidSubmission(res, activeSubmission.id, [alreadySubmittedError]);
+					}
 				}
 			}
 
@@ -82,11 +105,6 @@ export const submit = validateRequest(
 						'The "submissionFile" parameter is missing or empty. Please include a file in the request for processing.',
 					);
 				}
-				const activeSubmission = await lyricProvider.services.submission.getActiveSubmissionByOrganization({
-					categoryId,
-					username: user?.username || '',
-					organization,
-				});
 
 				if (!activeSubmission) {
 					throw new lyricProvider.utils.errors.BadRequest(

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -26,11 +26,8 @@ import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 import { prevalidateNewDataFile } from '@/submission/fileValidation.js';
-import {
-	findDuplicateSequencingMetadata,
-	handleSequencingMetadataSubmission,
-	handleSubmission,
-} from '@/submission/submissionHandler.js';
+import { findDuplicateSequencingMetadata } from '@/submission/sequencingPayload.js';
+import { handleSequencingMetadataSubmission, handleSubmission } from '@/submission/submissionHandler.js';
 import {
 	type ErrorResponse,
 	type SubmissionManifest,

--- a/src/db/schemas/record_analysis_map.ts
+++ b/src/db/schemas/record_analysis_map.ts
@@ -28,6 +28,7 @@ export const submissionFiles = schema.table(
 		submission_id: integer().notNull(),
 		record_identifier: varchar({ length: 255 }).notNull(),
 		analysis_id: varchar({ length: 255 }).notNull(),
+		md5_sum: varchar({ length: 255 }),
 		system_id: varchar({ length: 255 }),
 		created_at: timestamp().notNull().defaultNow(),
 	},

--- a/src/submission/fileValidation.ts
+++ b/src/submission/fileValidation.ts
@@ -215,7 +215,7 @@ export const buildSequencingFilesMetadata = (
 /**
  * Converters the Sequencing metadata to a payload format.
  */
-export const buildFileMetadata = (file: SequencingMetadataType & { identifier: string }) => {
+export const buildFileMetadata = (file: SequencingMetadataType & { identifier: string }): SequencingMetadataType => {
 	return {
 		fileName: file.fileName,
 		fileSize: file.fileSize,

--- a/src/submission/sequencingPayload.test.ts
+++ b/src/submission/sequencingPayload.test.ts
@@ -20,7 +20,70 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 
-import { buildSongSubmissionPayload, extractInsertRecordValues } from './sequencingPayload.js';
+import {
+	buildSongSubmissionPayload,
+	extractInsertRecordValues,
+	findAlreadySubmittedFiles,
+	findDuplicateSequencingMetadata,
+} from './sequencingPayload.js';
+
+const sequencingMetadata = (fileName: string, fileMd5sum: string) => ({
+	fileName,
+	fileSize: 100,
+	fileMd5sum,
+	fileAccess: 'open',
+	fileType: 'FASTQ',
+});
+
+suite('findDuplicateSequencingMetadata', () => {
+	test('returns every entry whose MD5 sum occurs more than once', () => {
+		const duplicateFirst = sequencingMetadata('SAMPLE001.fastq.gz', 'duplicate-md5');
+		const unique = sequencingMetadata('SAMPLE002.fastq.gz', 'unique-md5');
+		const duplicateSecond = sequencingMetadata('SAMPLE003.fastq.gz', 'duplicate-md5');
+
+		const result = findDuplicateSequencingMetadata([duplicateFirst, unique, duplicateSecond]);
+
+		assert.deepEqual(result, [duplicateFirst, duplicateSecond]);
+	});
+
+	test('returns no files when every MD5 sum is unique', () => {
+		const result = findDuplicateSequencingMetadata([
+			sequencingMetadata('SAMPLE001.fastq.gz', 'first-md5'),
+			sequencingMetadata('SAMPLE002.fastq.gz', 'second-md5'),
+		]);
+
+		assert.deepEqual(result, []);
+	});
+
+	test('ignores empty MD5 sums', () => {
+		const result = findDuplicateSequencingMetadata([
+			sequencingMetadata('SAMPLE001.fastq.gz', ''),
+			sequencingMetadata('SAMPLE002.fastq.gz', ''),
+		]);
+
+		assert.deepEqual(result, []);
+	});
+
+	test('matches duplicate MD5 sums case-insensitively', () => {
+		const uppercaseMd5 = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
+		const lowercaseMd5 = sequencingMetadata('SAMPLE002.fastq.gz', 'abc123');
+
+		const result = findDuplicateSequencingMetadata([uppercaseMd5, lowercaseMd5]);
+
+		assert.deepEqual(result, [uppercaseMd5, lowercaseMd5]);
+	});
+});
+
+suite('findAlreadySubmittedFiles', () => {
+	test('matches MD5 sums case-insensitively and ignores empty existing values', () => {
+		const matchingFile = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
+		const unmatchedFile = sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456');
+
+		const result = findAlreadySubmittedFiles([{ md5Sum: 'abc123' }, { md5Sum: '' }, {}], [matchingFile, unmatchedFile]);
+
+		assert.deepEqual(result, [matchingFile]);
+	});
+});
 
 suite('extractInsertRecordValues', () => {
 	test('returns an empty array when given no records', () => {

--- a/src/submission/sequencingPayload.test.ts
+++ b/src/submission/sequencingPayload.test.ts
@@ -20,14 +20,16 @@
 import assert from 'node:assert/strict';
 import { suite, test } from 'node:test';
 
+import type { SelectSubmissionFile } from '../db/schemas/record_analysis_map.js';
 import {
 	buildSongSubmissionPayload,
 	extractInsertRecordValues,
 	findAlreadySubmittedFiles,
 	findDuplicateSequencingMetadata,
 } from './sequencingPayload.js';
+import type { SequencingMetadataType } from './submitRequest.js';
 
-const sequencingMetadata = (fileName: string, fileMd5sum: string) => ({
+const sequencingMetadata = (fileName: string, fileMd5sum: string): SequencingMetadataType => ({
 	fileName,
 	fileSize: 100,
 	fileMd5sum,
@@ -37,16 +39,18 @@ const sequencingMetadata = (fileName: string, fileMd5sum: string) => ({
 
 const mappingSequencingMetadata = (
 	submissionId: number,
+	systemId: string,
 	recordIdentifier: string,
 	analysisId: string,
 	md5Sum: string,
-) => ({
+): SelectSubmissionFile => ({
 	id: 1,
+	system_id: systemId,
 	submission_id: submissionId,
 	record_identifier: recordIdentifier,
 	analysis_id: analysisId,
 	md5_sum: md5Sum,
-	created_at: Date.now().toString(),
+	created_at: new Date(),
 });
 
 suite('findDuplicateSequencingMetadata', () => {
@@ -90,29 +94,29 @@ suite('findDuplicateSequencingMetadata', () => {
 
 suite('findAlreadySubmittedFiles', () => {
 	test('matches MD5 sums case-insensitively', () => {
-		const exsistingFiles = [
-			mappingSequencingMetadata(1, 'SAMPLE001', 'ANALYSIS001', 'abc123'),
-			mappingSequencingMetadata(1, 'SAMPLE002', 'ANALYSIS002', 'xz789'),
+		const esistingFiles = [
+			mappingSequencingMetadata(1, 'system-1', 'SAMPLE001', 'ANALYSIS001', 'abc123'),
+			mappingSequencingMetadata(1, 'system-2', 'SAMPLE002', 'ANALYSIS002', 'xz789'),
 		];
 
 		const matchingFile = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
 		const unmatchedFile = sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456');
 
-		const result = findAlreadySubmittedFiles(exsistingFiles, [matchingFile, unmatchedFile]);
+		const result = findAlreadySubmittedFiles(esistingFiles, [matchingFile, unmatchedFile]);
 
 		assert.deepEqual(result, [matchingFile]);
 	});
 
 	test('ignores empty MD5 sums in existing files', () => {
-		const exsistingFiles = [
-			mappingSequencingMetadata(1, 'SAMPLE001', 'ANALYSIS001', ''),
-			mappingSequencingMetadata(1, 'SAMPLE002', 'ANALYSIS002', ''),
+		const esistingFiles = [
+			mappingSequencingMetadata(1, 'system-1', 'SAMPLE001', 'ANALYSIS001', ''),
+			mappingSequencingMetadata(1, 'system-2', 'SAMPLE002', 'ANALYSIS002', ''),
 		];
 
 		const unmatchedFile1 = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
 		const unmatchedFile2 = sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456');
 
-		const result = findAlreadySubmittedFiles(exsistingFiles, [unmatchedFile1, unmatchedFile2]);
+		const result = findAlreadySubmittedFiles(esistingFiles, [unmatchedFile1, unmatchedFile2]);
 
 		assert.deepEqual(result, []);
 	});

--- a/src/submission/sequencingPayload.test.ts
+++ b/src/submission/sequencingPayload.test.ts
@@ -35,6 +35,20 @@ const sequencingMetadata = (fileName: string, fileMd5sum: string) => ({
 	fileType: 'FASTQ',
 });
 
+const mappingSequencingMetadata = (
+	submissionId: number,
+	recordIdentifier: string,
+	analysisId: string,
+	md5Sum: string,
+) => ({
+	id: 1,
+	submission_id: submissionId,
+	record_identifier: recordIdentifier,
+	analysis_id: analysisId,
+	md5_sum: md5Sum,
+	created_at: Date.now().toString(),
+});
+
 suite('findDuplicateSequencingMetadata', () => {
 	test('returns every entry whose MD5 sum occurs more than once', () => {
 		const duplicateFirst = sequencingMetadata('SAMPLE001.fastq.gz', 'duplicate-md5');
@@ -75,13 +89,32 @@ suite('findDuplicateSequencingMetadata', () => {
 });
 
 suite('findAlreadySubmittedFiles', () => {
-	test('matches MD5 sums case-insensitively and ignores empty existing values', () => {
+	test('matches MD5 sums case-insensitively', () => {
+		const exsistingFiles = [
+			mappingSequencingMetadata(1, 'SAMPLE001', 'ANALYSIS001', 'abc123'),
+			mappingSequencingMetadata(1, 'SAMPLE002', 'ANALYSIS002', 'xz789'),
+		];
+
 		const matchingFile = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
 		const unmatchedFile = sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456');
 
-		const result = findAlreadySubmittedFiles([{ md5Sum: 'abc123' }, { md5Sum: '' }, {}], [matchingFile, unmatchedFile]);
+		const result = findAlreadySubmittedFiles(exsistingFiles, [matchingFile, unmatchedFile]);
 
 		assert.deepEqual(result, [matchingFile]);
+	});
+
+	test('ignores empty MD5 sums in existing files', () => {
+		const exsistingFiles = [
+			mappingSequencingMetadata(1, 'SAMPLE001', 'ANALYSIS001', ''),
+			mappingSequencingMetadata(1, 'SAMPLE002', 'ANALYSIS002', ''),
+		];
+
+		const unmatchedFile1 = sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123');
+		const unmatchedFile2 = sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456');
+
+		const result = findAlreadySubmittedFiles(exsistingFiles, [unmatchedFile1, unmatchedFile2]);
+
+		assert.deepEqual(result, []);
 	});
 });
 

--- a/src/submission/sequencingPayload.test.ts
+++ b/src/submission/sequencingPayload.test.ts
@@ -26,6 +26,8 @@ import {
 	extractInsertRecordValues,
 	findAlreadySubmittedFiles,
 	findDuplicateSequencingMetadata,
+	getAlreadySubmittedFilesError,
+	getDuplicateSequencingMetadataError,
 } from './sequencingPayload.js';
 import type { SequencingMetadataType } from './submitRequest.js';
 
@@ -119,6 +121,54 @@ suite('findAlreadySubmittedFiles', () => {
 		const result = findAlreadySubmittedFiles(esistingFiles, [unmatchedFile1, unmatchedFile2]);
 
 		assert.deepEqual(result, []);
+	});
+});
+
+suite('getDuplicateSequencingMetadataError', () => {
+	test('returns a batch error for duplicate md5 sums in the input metadata', () => {
+		const duplicateFirst = sequencingMetadata('SAMPLE001.fastq.gz', 'duplicate-md5');
+		const duplicateSecond = sequencingMetadata('SAMPLE003.fastq.gz', 'duplicate-md5');
+
+		const result = getDuplicateSequencingMetadataError([duplicateFirst, duplicateSecond], 'main-file.fastq.gz');
+
+		assert.deepEqual(result, {
+			message: 'The following files have duplicate md5sum values: SAMPLE001.fastq.gz, SAMPLE003.fastq.gz',
+			type: 'INCORRECT_SECTION',
+			batchName: 'main-file.fastq.gz',
+		});
+	});
+
+	test('returns undefined when the provided metadata has no duplicate md5 sums', () => {
+		const result = getDuplicateSequencingMetadataError(
+			[sequencingMetadata('SAMPLE001.fastq.gz', 'first-md5'), sequencingMetadata('SAMPLE002.fastq.gz', 'second-md5')],
+			'main-file.fastq.gz',
+		);
+
+		assert.equal(result, undefined);
+	});
+});
+
+suite('getAlreadySubmittedFilesError', () => {
+	test('returns a batch error when metadata files were already submitted for the active submission', () => {
+		const existingFiles = [mappingSequencingMetadata(1, 'system-1', 'SAMPLE001', 'ANALYSIS001', 'abc123')];
+		const submittedMetadata = [sequencingMetadata('SAMPLE001.fastq.gz', 'ABC123')];
+
+		const result = getAlreadySubmittedFilesError(existingFiles, submittedMetadata, 'main-file.fastq.gz');
+
+		assert.deepEqual(result, {
+			message: 'The following files have already been submitted for this submission: SAMPLE001.fastq.gz',
+			type: 'INCORRECT_SECTION',
+			batchName: 'main-file.fastq.gz',
+		});
+	});
+
+	test('returns undefined when none of the sequencing metadata matches existing submission files', () => {
+		const existingFiles = [mappingSequencingMetadata(1, 'system-1', 'SAMPLE001', 'ANALYSIS001', 'abc123')];
+		const metadata = [sequencingMetadata('SAMPLE002.fastq.gz', 'DEF456')];
+
+		const result = getAlreadySubmittedFilesError(existingFiles, metadata, 'main-file.fastq.gz');
+
+		assert.equal(result, undefined);
 	});
 });
 

--- a/src/submission/sequencingPayload.ts
+++ b/src/submission/sequencingPayload.ts
@@ -17,6 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { BATCH_ERROR_TYPE, type BatchError } from '@overture-stack/lyric';
+
 import type { SelectSubmissionFile } from '@/db/schemas/record_analysis_map.js';
 import type { SequencingMetadataType } from '@/submission/submitRequest.js';
 
@@ -58,6 +60,52 @@ export const findAlreadySubmittedFiles = (
 	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5_sum }) => (md5_sum ? [md5_sum.toLowerCase()] : [])));
 
 	return sequencingMetadataValues.filter((metadata) => existingMd5Sums.has(metadata.fileMd5sum.toLowerCase()));
+};
+
+/**
+ * Returns a BatchError if there are duplicate sequencing metadata entries, otherwise returns undefined.
+ * @param sequencingMetadataValues - The sequencing metadata values to check for duplicates
+ * @param batchName - The name of the batch, used in the error message if duplicates are found
+ * @returns A BatchError if duplicates are found, otherwise undefined
+ */
+export const getDuplicateSequencingMetadataError = (
+	sequencingMetadataValues: SequencingMetadataType[],
+	batchName?: string,
+): BatchError | undefined => {
+	const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
+	if (!duplicateMetadataFiles.length) {
+		return undefined;
+	}
+
+	return {
+		message: `The following files have duplicate md5sum values: ${duplicateMetadataFiles.map((metadata) => metadata.fileName).join(', ')}`,
+		type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+		batchName: batchName || '',
+	};
+};
+
+/**
+ * Returns a BatchError if there are already submitted files, otherwise returns undefined.
+ * @param existingFiles - The existing submitted files to check against
+ * @param sequencingMetadataValues - The sequencing metadata values to check for already submitted files
+ * @param batchName - The name of the batch, used in the error message if already submitted files are found
+ * @returns A BatchError if already submitted files are found, otherwise undefined
+ */
+export const getAlreadySubmittedFilesError = (
+	existingFiles: SelectSubmissionFile[],
+	sequencingMetadataValues: SequencingMetadataType[],
+	batchName?: string,
+): BatchError | undefined => {
+	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingFiles, sequencingMetadataValues);
+	if (!alreadySubmittedFiles.length) {
+		return undefined;
+	}
+
+	return {
+		message: `The following files have already been submitted for this submission: ${alreadySubmittedFiles.map((file) => file.fileName).join(', ')}`,
+		type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+		batchName: batchName || '',
+	};
 };
 
 /**

--- a/src/submission/sequencingPayload.ts
+++ b/src/submission/sequencingPayload.ts
@@ -27,6 +27,35 @@ const SEQUENCING_TEMPLATE = 'sequencing_payload.json' as const;
 const DATA_PREFIX = 'data.' as const;
 
 /**
+ * Returns metadata entries whose MD5 sum occurs more than once in the input.
+ * If the MD5 sum is empty, it is ignored and not considered a duplicate.
+ */
+export const findDuplicateSequencingMetadata = (
+	sequencingMetadataValues: SequencingMetadataType[],
+): SequencingMetadataType[] => {
+	const metadataWithMd5sums = sequencingMetadataValues.filter(({ fileMd5sum }) => Boolean(fileMd5sum));
+	const md5sumCounts = metadataWithMd5sums.reduce((counts, metadata) => {
+		const normalizedMd5sum = metadata.fileMd5sum.toLowerCase();
+		return counts.set(normalizedMd5sum, (counts.get(normalizedMd5sum) ?? 0) + 1);
+	}, new Map<string, number>());
+
+	return metadataWithMd5sums.filter((metadata) => (md5sumCounts.get(metadata.fileMd5sum.toLowerCase()) ?? 0) > 1);
+};
+
+/**
+ * Returns sequencing metadata whose MD5 sum is already present in submitted files.
+ * If the MD5 sum is empty, it is ignored and not considered a duplicate.
+ */
+export const findAlreadySubmittedFiles = (
+	existingFiles: { md5Sum?: string }[],
+	sequencingMetadataValues: SequencingMetadataType[],
+): SequencingMetadataType[] => {
+	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5Sum }) => (md5Sum ? [md5Sum.toLowerCase()] : [])));
+
+	return sequencingMetadataValues.filter((metadata) => existingMd5Sums.has(metadata.fileMd5sum.toLowerCase()));
+};
+
+/**
  * Builds the Song payload based on the Sequencing files Metadata
  * @param param0
  * @returns

--- a/src/submission/sequencingPayload.ts
+++ b/src/submission/sequencingPayload.ts
@@ -27,6 +27,10 @@ import { convertRecordToPayload, prefixKeys } from './populateTemplate.js';
 const SEQUENCING_TEMPLATE = 'sequencing_payload.json' as const;
 const DATA_PREFIX = 'data.' as const;
 
+export type SongSubmissionPayload = Record<string, any> & {
+	files: SequencingMetadataType[];
+};
+
 /**
  * Returns metadata entries whose MD5 sum occurs more than once in the input.
  * If the MD5 sum is empty, it is ignored and not considered a duplicate.
@@ -71,8 +75,8 @@ export const buildSongSubmissionPayload = ({
 	extractedData: Record<string, string>[];
 	organization: string;
 	fileNameIdentifier: string;
-}): Record<string, any>[] => {
-	const songSubmissionData: Record<string, any>[] = [];
+}): SongSubmissionPayload[] => {
+	const songSubmissionData: SongSubmissionPayload[] = [];
 	// Convert Sequencing metadata to payload
 	for (const filesMetadata of sequencingFilesMetadata) {
 		const matchedRecord = extractedData.find((record) => record[fileNameIdentifier] === filesMetadata.identifier);
@@ -82,9 +86,11 @@ export const buildSongSubmissionPayload = ({
 		}
 
 		const prefixedRecord = prefixKeys(matchedRecord, DATA_PREFIX);
-		const songPayload = convertRecordToPayload({ organization, ...prefixedRecord }, SEQUENCING_TEMPLATE);
 		// TODO: Handle multiple files by same identifier
-		songPayload.files = [buildFileMetadata(filesMetadata)];
+		const songPayload: SongSubmissionPayload = {
+			...convertRecordToPayload({ organization, ...prefixedRecord }, SEQUENCING_TEMPLATE),
+			files: [buildFileMetadata(filesMetadata)], // Only 1s sequencing file per record is expected, but we can extend this in the future if needed
+		};
 
 		songSubmissionData.push(songPayload);
 	}

--- a/src/submission/sequencingPayload.ts
+++ b/src/submission/sequencingPayload.ts
@@ -17,6 +17,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import type { SelectSubmissionFile } from '@/db/schemas/record_analysis_map.js';
 import type { SequencingMetadataType } from '@/submission/submitRequest.js';
 
 import { buildFileMetadata } from './fileValidation.js';
@@ -47,10 +48,10 @@ export const findDuplicateSequencingMetadata = (
  * If the MD5 sum is empty, it is ignored and not considered a duplicate.
  */
 export const findAlreadySubmittedFiles = (
-	existingFiles: { md5Sum?: string }[],
+	existingFiles: SelectSubmissionFile[],
 	sequencingMetadataValues: SequencingMetadataType[],
 ): SequencingMetadataType[] => {
-	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5Sum }) => (md5Sum ? [md5Sum.toLowerCase()] : [])));
+	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5_sum }) => (md5_sum ? [md5_sum.toLowerCase()] : [])));
 
 	return sequencingMetadataValues.filter((metadata) => existingMd5Sums.has(metadata.fileMd5sum.toLowerCase()));
 };

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -33,12 +33,15 @@ import { buildSubmissionFileMetadata } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
-import type { FileMetadata } from '../controllers/submission/getSubmissionById.js';
 import { getDbInstance } from '../db/index.js';
 import { fileRepository } from '../repository/fileRepository.js';
 import { buildSequencingFilesMetadata } from './fileValidation.js';
 import { parseFileToRecords } from './readFile.js';
-import { buildSongSubmissionPayload, extractInsertRecordValues } from './sequencingPayload.js';
+import {
+	buildSongSubmissionPayload,
+	extractInsertRecordValues,
+	findAlreadySubmittedFiles,
+} from './sequencingPayload.js';
 
 interface SuccessSubmissionResult {
 	success: true;
@@ -262,29 +265,6 @@ export async function handleSubmission({
 		submissionManifest: manifest,
 	};
 }
-
-/**
- * Finds duplicate files in the sequencing metadata values based on their md5sum
- */
-export const findDuplicateSequencingMetadata = (
-	sequencingMetadataValues: SequencingMetadataType[],
-): SequencingMetadataType[] => {
-	const md5sumCounts = sequencingMetadataValues.reduce(
-		(counts, metadata) => counts.set(metadata.fileMd5sum, (counts.get(metadata.fileMd5sum) ?? 0) + 1),
-		new Map<string, number>(),
-	);
-
-	return sequencingMetadataValues.filter((metadata) => (md5sumCounts.get(metadata.fileMd5sum) ?? 0) > 1);
-};
-
-const findAlreadySubmittedFiles = (
-	existingFiles: FileMetadata[],
-	sequencingMetadataValues: SequencingMetadataType[],
-): SequencingMetadataType[] => {
-	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5Sum }) => (md5Sum ? [md5Sum.toLowerCase()] : [])));
-
-	return sequencingMetadataValues.filter((metadata) => existingMd5Sums.has(metadata.fileMd5sum.toLowerCase()));
-};
 
 /**
  * Handles submission of sequencing metadata against an already active Submission,

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -315,7 +315,7 @@ export async function handleSequencingMetadataSubmission({
 		};
 	}
 
-	// Input validation - Find duplicate md5sums in senquencing metadata input
+	// Input validation - Find duplicate md5sums in sequencing metadata input
 	const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
 
 	if (duplicateMetadataFiles.length) {
@@ -332,7 +332,7 @@ export async function handleSequencingMetadataSubmission({
 		};
 	}
 
-	// Submission valiation - Find any duplicates againt submisison file metadata
+	// Submission validation - Find any duplicates against submission file metadata
 	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
 	const alreadySubmittedFiles = sequencingMetadataValues.filter((metadata) =>
 		existingFiles.find((existing) => existing.md5Sum === metadata.fileMd5sum),

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -265,7 +265,7 @@ export async function handleSubmission({
 /**
  * Finds duplicate files in the sequencing metadata values based on their md5sum
  */
-const findDuplicateSequencingMetadata = (
+export const findDuplicateSequencingMetadata = (
 	sequencingMetadataValues: SequencingMetadataType[],
 ): SequencingMetadataType[] => {
 	const metadataFileNamesByMd5sum = sequencingMetadataValues.reduce(
@@ -308,23 +308,6 @@ export async function handleSequencingMetadataSubmission({
 			errors: [
 				{
 					message: 'Sequencing file submission is not enabled for this category.',
-					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-					batchName,
-				},
-			],
-		};
-	}
-
-	// Input validation - Find duplicate md5sums in sequencing metadata input
-	const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
-
-	if (duplicateMetadataFiles.length) {
-		return {
-			success: false,
-			submissionId,
-			errors: [
-				{
-					message: `The following files have duplicate md5sum values: ${duplicateMetadataFiles.map((metadata) => metadata.fileName).join(', ')}`,
 					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
 					batchName,
 				},

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -263,6 +263,21 @@ export async function handleSubmission({
 }
 
 /**
+ * Finds duplicate files in the sequencing metadata values based on their md5sum
+ */
+const findDuplicateSequencingMetadata = (
+	sequencingMetadataValues: SequencingMetadataType[],
+): SequencingMetadataType[] => {
+	const metadataFileNamesByMd5sum = sequencingMetadataValues.reduce(
+		(fileNamesByMd5sum, metadata) =>
+			fileNamesByMd5sum.set(metadata.fileMd5sum, [...(fileNamesByMd5sum.get(metadata.fileMd5sum) ?? []), metadata]),
+		new Map<string, SequencingMetadataType[]>(),
+	);
+
+	return [...metadataFileNamesByMd5sum.values()].filter((files) => files.length > 1).flat();
+};
+
+/**
  * Handles submission of sequencing metadata against an already active Submission,
  * with no new submission file. Matches the provided sequencing metadata against the
  * clinical records already staged on the active Submission and submits the resulting
@@ -293,6 +308,43 @@ export async function handleSequencingMetadataSubmission({
 			errors: [
 				{
 					message: 'Sequencing file submission is not enabled for this category.',
+					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+					batchName,
+				},
+			],
+		};
+	}
+
+	// Input validation - Find duplicate md5sums in senquencing metadata input
+	const duplicateMetadataFiles = findDuplicateSequencingMetadata(sequencingMetadataValues);
+
+	if (duplicateMetadataFiles.length) {
+		return {
+			success: false,
+			submissionId,
+			errors: [
+				{
+					message: `The following files have duplicate md5sum values: ${duplicateMetadataFiles.map((metadata) => metadata.fileName).join(', ')}`,
+					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+					batchName,
+				},
+			],
+		};
+	}
+
+	// Submission valiation - Find any duplicates againt submisison file metadata
+	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
+	const alreadySubmittedFiles = sequencingMetadataValues.filter((metadata) =>
+		existingFiles.find((existing) => existing.md5Sum === metadata.fileMd5sum),
+	);
+
+	if (alreadySubmittedFiles.length) {
+		return {
+			success: false,
+			submissionId,
+			errors: [
+				{
+					message: `The following files have already been submitted for this submission: ${alreadySubmittedFiles.map((file) => file.fileName).join(', ')}`,
 					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
 					batchName,
 				},
@@ -354,7 +406,6 @@ export async function handleSequencingMetadataSubmission({
 	}
 
 	// Combine the Submission's existing files with the newly submitted sequencing files
-	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
 	const newFiles = await buildSubmissionManifest(songSubmissionResult.analysisIds, organization);
 
 	const submissionManifest: SubmissionManifest[] = [

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -28,13 +28,13 @@ import {
 import { env } from '@/common/envConfig.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
+import { getDbInstance } from '@/db/index.js';
 import { type InsertSubmissionFile } from '@/db/schemas/index.js';
+import { fileRepository } from '@/repository/fileRepository.js';
 import { buildSubmissionFileMetadata, fetchSubmissionFilesBySubmissionId } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
-import { getDbInstance } from '../db/index.js';
-import { fileRepository } from '../repository/fileRepository.js';
 import { buildSequencingFilesMetadata } from './fileValidation.js';
 import { parseFileToRecords } from './readFile.js';
 import {
@@ -55,6 +55,21 @@ interface ErrorSubmissionResult {
 	submissionId?: number;
 	errors: BatchError[];
 }
+
+const createSubmissionError = (message: string, submissionId: number, batchName: string): ErrorSubmissionResult => {
+	logger.info(message);
+	return {
+		success: false,
+		submissionId,
+		errors: [
+			{
+				message,
+				type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
+				batchName,
+			},
+		],
+	};
+};
 
 /**
  * Constructs an array of data to be used for the file Manifest
@@ -293,17 +308,11 @@ export async function handleSequencingMetadataSubmission({
 	const batchName = `Submission ${submissionId}`;
 
 	if (!fileNameIdentifier || !sequencingEnabled) {
-		return {
-			success: false,
+		return createSubmissionError(
+			'Sequencing file submission is not enabled for this category.',
 			submissionId,
-			errors: [
-				{
-					message: 'Sequencing file submission is not enabled for this category.',
-					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-					batchName,
-				},
-			],
-		};
+			batchName,
+		);
 	}
 
 	// Submission validation - Find any duplicates against submission file metadata
@@ -311,17 +320,8 @@ export async function handleSequencingMetadataSubmission({
 	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingSubmissionFiles, sequencingMetadataValues);
 
 	if (alreadySubmittedFiles.length) {
-		return {
-			success: false,
-			submissionId,
-			errors: [
-				{
-					message: `The following files have already been submitted for this submission: ${alreadySubmittedFiles.map((file) => file.fileName).join(', ')}`,
-					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-					batchName,
-				},
-			],
-		};
+		const errorMessage = `The following files have already been submitted for this submission: ${alreadySubmittedFiles.map((file) => file.fileName).join(', ')}`;
+		return createSubmissionError(errorMessage, submissionId, batchName);
 	}
 
 	// Grab the clinical records already staged on the active Submission to match against the sequencing metadata
@@ -352,17 +352,11 @@ export async function handleSequencingMetadataSubmission({
 	});
 
 	if (!songSubmissionData.length) {
-		return {
-			success: false,
+		return createSubmissionError(
+			'No sequencing files matched the records of the current active Submission.',
 			submissionId,
-			errors: [
-				{
-					message: 'No sequencing files matched the records of the current active Submission.',
-					type: BATCH_ERROR_TYPE.INCORRECT_SECTION,
-					batchName,
-				},
-			],
-		};
+			batchName,
+		);
 	}
 
 	const songSubmissionResult = await submitSongPayload(

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -29,7 +29,7 @@ import { env } from '@/common/envConfig.js';
 import logger from '@/common/logger.js';
 import { lyricProvider } from '@/core/provider.js';
 import { type InsertSubmissionFile } from '@/db/schemas/index.js';
-import { buildSubmissionFileMetadata } from '@/service/fileService.js';
+import { buildSubmissionFileMetadata, fetchSubmissionFilesBySubmissionId } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
@@ -108,6 +108,7 @@ const submitSongPayload = async (
 				analysis_id: result.analysisId,
 				submission_id: submissionId,
 				record_identifier: record[fileNameIdentifier],
+				md5_sum: record.data?.fileMd5sum || '',
 			});
 		} catch (error) {
 			songErrors.push({
@@ -305,8 +306,8 @@ export async function handleSequencingMetadataSubmission({
 	}
 
 	// Submission validation - Find any duplicates against submission file metadata
-	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
-	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingFiles, sequencingMetadataValues);
+	const existingSubmissionFiles = await fetchSubmissionFilesBySubmissionId(submissionId);
+	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingSubmissionFiles, sequencingMetadataValues);
 
 	if (alreadySubmittedFiles.length) {
 		return {
@@ -376,6 +377,7 @@ export async function handleSequencingMetadataSubmission({
 	}
 
 	// Combine the Submission's existing files with the newly submitted sequencing files
+	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
 	const newFiles = await buildSubmissionManifest(songSubmissionResult.analysisIds, organization);
 
 	const submissionManifest: SubmissionManifest[] = [

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -31,7 +31,7 @@ import { lyricProvider } from '@/core/provider.js';
 import { getDbInstance } from '@/db/index.js';
 import { type InsertSubmissionFile } from '@/db/schemas/index.js';
 import { fileRepository } from '@/repository/fileRepository.js';
-import { buildSubmissionFileMetadata, fetchSubmissionFilesBySubmissionId } from '@/service/fileService.js';
+import { buildSubmissionFileMetadata } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
@@ -40,7 +40,6 @@ import { parseFileToRecords } from './readFile.js';
 import {
 	buildSongSubmissionPayload,
 	extractInsertRecordValues,
-	findAlreadySubmittedFiles,
 	type SongSubmissionPayload,
 } from './sequencingPayload.js';
 
@@ -149,7 +148,7 @@ const submitSongPayload = async (
 	}
 
 	try {
-		fileRepo.saveSubmissionFiles(insertSubmissionFiles);
+		await fileRepo.saveSubmissionFiles(insertSubmissionFiles);
 	} catch (error) {
 		logger.error(error, 'An error ocurring storing submission files mapping.');
 		// Lyric submission + Song Submission was successful, but storing submission files mapping failed
@@ -313,15 +312,6 @@ export async function handleSequencingMetadataSubmission({
 			submissionId,
 			batchName,
 		);
-	}
-
-	// Submission validation - Find any duplicates against submission file metadata
-	const existingSubmissionFiles = await fetchSubmissionFilesBySubmissionId(submissionId);
-	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingSubmissionFiles, sequencingMetadataValues);
-
-	if (alreadySubmittedFiles.length) {
-		const errorMessage = `The following files have already been submitted for this submission: ${alreadySubmittedFiles.map((file) => file.fileName).join(', ')}`;
-		return createSubmissionError(errorMessage, submissionId, batchName);
 	}
 
 	// Grab the clinical records already staged on the active Submission to match against the sequencing metadata

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -41,6 +41,7 @@ import {
 	buildSongSubmissionPayload,
 	extractInsertRecordValues,
 	findAlreadySubmittedFiles,
+	type SongSubmissionPayload,
 } from './sequencingPayload.js';
 
 interface SuccessSubmissionResult {
@@ -86,7 +87,7 @@ const buildSubmissionManifest = async (analysisIds: string[], organization: stri
  * @returns
  */
 const submitSongPayload = async (
-	songSubmissionData: Record<string, any>[],
+	songSubmissionData: SongSubmissionPayload[],
 	organization: string,
 	submissionId: number,
 	fileNameIdentifier: string,
@@ -108,7 +109,7 @@ const submitSongPayload = async (
 				analysis_id: result.analysisId,
 				submission_id: submissionId,
 				record_identifier: record[fileNameIdentifier],
-				md5_sum: record.data?.fileMd5sum || '',
+				md5_sum: record.files[0]?.fileMd5sum || '',
 			});
 		} catch (error) {
 			songErrors.push({
@@ -182,7 +183,7 @@ export async function handleSubmission({
 
 	const extractedData = await parseFileToRecords(submissionFile, schema);
 
-	const songSubmissionData: Record<string, any>[] = [];
+	const songSubmissionData: SongSubmissionPayload[] = [];
 
 	// Build Sequencing metadata
 	if (sequencingMetadataValues) {

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -269,13 +269,12 @@ export async function handleSubmission({
 export const findDuplicateSequencingMetadata = (
 	sequencingMetadataValues: SequencingMetadataType[],
 ): SequencingMetadataType[] => {
-	const metadataFileNamesByMd5sum = sequencingMetadataValues.reduce(
-		(fileNamesByMd5sum, metadata) =>
-			fileNamesByMd5sum.set(metadata.fileMd5sum, [...(fileNamesByMd5sum.get(metadata.fileMd5sum) ?? []), metadata]),
-		new Map<string, SequencingMetadataType[]>(),
+	const md5sumCounts = sequencingMetadataValues.reduce(
+		(counts, metadata) => counts.set(metadata.fileMd5sum, (counts.get(metadata.fileMd5sum) ?? 0) + 1),
+		new Map<string, number>(),
 	);
 
-	return [...metadataFileNamesByMd5sum.values()].filter((files) => files.length > 1).flat();
+	return sequencingMetadataValues.filter((metadata) => (md5sumCounts.get(metadata.fileMd5sum) ?? 0) > 1);
 };
 
 const findAlreadySubmittedFiles = (

--- a/src/submission/submissionHandler.ts
+++ b/src/submission/submissionHandler.ts
@@ -33,6 +33,7 @@ import { buildSubmissionFileMetadata } from '@/service/fileService.js';
 import { getAnalysisFilesByAnalysisId, submit as songSubmit } from '@/submission/song.js';
 import type { SequencingMetadataType, SubmissionManifest } from '@/submission/submitRequest.js';
 
+import type { FileMetadata } from '../controllers/submission/getSubmissionById.js';
 import { getDbInstance } from '../db/index.js';
 import { fileRepository } from '../repository/fileRepository.js';
 import { buildSequencingFilesMetadata } from './fileValidation.js';
@@ -277,6 +278,15 @@ export const findDuplicateSequencingMetadata = (
 	return [...metadataFileNamesByMd5sum.values()].filter((files) => files.length > 1).flat();
 };
 
+const findAlreadySubmittedFiles = (
+	existingFiles: FileMetadata[],
+	sequencingMetadataValues: SequencingMetadataType[],
+): SequencingMetadataType[] => {
+	const existingMd5Sums = new Set(existingFiles.flatMap(({ md5Sum }) => (md5Sum ? [md5Sum.toLowerCase()] : [])));
+
+	return sequencingMetadataValues.filter((metadata) => existingMd5Sums.has(metadata.fileMd5sum.toLowerCase()));
+};
+
 /**
  * Handles submission of sequencing metadata against an already active Submission,
  * with no new submission file. Matches the provided sequencing metadata against the
@@ -317,9 +327,7 @@ export async function handleSequencingMetadataSubmission({
 
 	// Submission validation - Find any duplicates against submission file metadata
 	const existingFiles = await buildSubmissionFileMetadata(organization, submissionId);
-	const alreadySubmittedFiles = sequencingMetadataValues.filter((metadata) =>
-		existingFiles.find((existing) => existing.md5Sum === metadata.fileMd5sum),
-	);
+	const alreadySubmittedFiles = findAlreadySubmittedFiles(existingFiles, sequencingMetadataValues);
 
 	if (alreadySubmittedFiles.length) {
 		return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
 	},
 	"include": ["./src/**/*.ts", "register.ts", "./src/templates/*.json"],
-	"exclude": ["dist", "node_modules", "**/*.spec.ts", "**/*.test.ts", "*.config.js"]
+	"exclude": ["dist", "node_modules", "*.config.js"]
 }


### PR DESCRIPTION
# Description
This PR intercepts duplicates in submitting sequencing files metadata and returns the corresponding error

The submit endpoint will return a 200 OK response  with status **INVALID_SUBMISSION**, and a message indicating what files are duplicated.

Example:
```json
{
    "submissionId": 108,
    "status": "INVALID_SUBMISSION",
    "submissionManifest": [],
    "batchErrors": [
        {
            "message": "The following files have already been submitted for this submission: 21-WW-BAR-01-Illumina-20.tar.xz",
            "type": "INCORRECT_SECTION",
            "batchName": "Submission 108"
        }
    ]
}
```

## More details
- **New Drizzle Migration:** Added `md5_sum` column to the `record_analysis_map` table to store the MD5 checksum of submitted sequencing files. (`0003_add_md5_sum_column_map_table.sql`)
- **Unit Tests:** Added coverage for `findDuplicateSequencingMetadata` and `findAlreadySubmittedFiles`. (`sequencingPayload.test.ts`)

## Related Issue
- https://github.com/imicroseq/roadmap/issues/175